### PR TITLE
feat: Improve key discoverability

### DIFF
--- a/programs/keyring-network/src/common/error.rs
+++ b/programs/keyring-network/src/common/error.rs
@@ -28,4 +28,6 @@ pub enum KeyringError {
     ErrAuthMessageParameterOutOfRange,
     #[msg("Invalid chain id")]
     ErrInvalidChainId,
+    #[msg("Number of keys breached max active key limit")]
+    ErrBreachedMaxActiveKeyLimit,
 }

--- a/programs/keyring-network/src/common/types.rs
+++ b/programs/keyring-network/src/common/types.rs
@@ -1,6 +1,9 @@
 use anchor_lang::account;
 use anchor_lang::prelude::*;
-use anchor_lang::solana_program::keccak::{hash, Hash};
+use anchor_lang::solana_program::{
+    keccak::{hash, Hash},
+    secp256k1_recover::SECP256K1_PUBLIC_KEY_LENGTH,
+};
 
 pub const CURRENT_VERSION: u8 = 1;
 
@@ -25,6 +28,18 @@ pub struct KeyEntry {
 
 impl KeyEntry {
     pub const MAX_SIZE: usize = 1 + 8 + 8 + 1;
+}
+
+pub const MAX_ACTIVE_KEYS: u8 = 10;
+
+#[account]
+#[derive(Debug, PartialEq)]
+pub struct KeyRegistry {
+    pub active_keys: Vec<Vec<u8>>,
+}
+
+impl KeyRegistry {
+    pub const MAX_SIZE: usize = SECP256K1_PUBLIC_KEY_LENGTH * MAX_ACTIVE_KEYS as usize;
 }
 
 pub trait ToHash {

--- a/programs/keyring-network/src/init.rs
+++ b/programs/keyring-network/src/init.rs
@@ -1,5 +1,5 @@
 use crate::common::error::KeyringError;
-use crate::common::types::{ChainId, ProgramState, CURRENT_VERSION};
+use crate::common::types::{ChainId, KeyRegistry, ProgramState, CURRENT_VERSION};
 use anchor_lang::prelude::*;
 use anchor_lang::Accounts;
 
@@ -19,6 +19,14 @@ pub struct Initialize<'info> {
         space = 8 + ProgramState::MAX_SIZE
     )]
     pub program_state: Account<'info, ProgramState>,
+    #[account(
+        init,
+        payer = signer,
+        seeds = [b"keyring_program".as_ref(), b"active_keys".as_ref()],
+        bump,
+        space = 8 + KeyRegistry::MAX_SIZE
+    )]
+    pub key_registry: Account<'info, KeyRegistry>,
     #[account(mut)]
     pub signer: Signer<'info>,
     pub system_program: Program<'info, System>,

--- a/scripts/initialize.ts
+++ b/scripts/initialize.ts
@@ -2,7 +2,7 @@ import * as anchor from "@coral-xyz/anchor";
 
 import { setup } from "./utils/setup";
 import { Config } from "./utils/types";
-import { getProgramStatePda } from "./utils/getPda";
+import { getKeyRegistryPda, getProgramStatePda } from "./utils/getPda";
 
 async function initialize() {
     const config: Config = await setup();
@@ -16,6 +16,7 @@ async function initialize() {
         .initialize(bufferSolanaChainId)
         .accounts({
             programState: getProgramStatePda(config.program.programId),
+            keyRegistry: getKeyRegistryPda(config.program.programId),
             signer: config.provider.wallet.publicKey,
             systemProgram: anchor.web3.SystemProgram.programId,
         })

--- a/scripts/registerKey.ts
+++ b/scripts/registerKey.ts
@@ -2,7 +2,11 @@ import * as anchor from "@coral-xyz/anchor";
 
 import { setup } from "./utils/setup";
 import { Config } from "./utils/types";
-import { getProgramStatePda, getKeyMappingPda } from "./utils/getPda";
+import {
+    getProgramStatePda,
+    getKeyMappingPda,
+    getKeyRegistryPda,
+} from "./utils/getPda";
 
 async function registerKey() {
     const config: Config = await setup();
@@ -23,6 +27,7 @@ async function registerKey() {
         .registerKey(key, new anchor.BN(validFrom), new anchor.BN(validUntil))
         .accounts({
             programState: getProgramStatePda(config.program.programId),
+            keyRegistry: getKeyRegistryPda(config.program.programId),
             signer: config.provider.wallet.publicKey,
             keyMapping: getKeyMappingPda(key, config.program.programId),
             systemProgram: anchor.web3.SystemProgram.programId,

--- a/scripts/utils/getPda.ts
+++ b/scripts/utils/getPda.ts
@@ -9,6 +9,12 @@ const getProgramStatePda = (programId: anchor.web3.PublicKey) =>
         programId
     )[0];
 
+const getKeyRegistryPda = (programId: anchor.web3.PublicKey) =>
+    anchor.web3.PublicKey.findProgramAddressSync(
+        [Buffer.from("keyring_program"), Buffer.from("active_keys")],
+        programId
+    )[0];
+
 const getKeyMappingPda = (
     key: Buffer<ArrayBuffer>,
     programId: anchor.web3.PublicKey
@@ -22,4 +28,4 @@ const getKeyMappingPda = (
         programId
     )[0];
 
-export { getProgramStatePda, getKeyMappingPda };
+export { getProgramStatePda, getKeyRegistryPda, getKeyMappingPda };

--- a/scripts/utils/setup.ts
+++ b/scripts/utils/setup.ts
@@ -3,7 +3,6 @@ import * as idl from "../../target/idl/keyring_network.json";
 import { KeyringNetwork } from "../../target/types/keyring_network";
 
 import { Config } from "./types";
-import { getKeyMappingPda, getProgramStatePda } from "./getPda";
 
 async function setup(): Promise<Config> {
     const stringKeypair = process.env.KEYPAIR || "";

--- a/tests/src/common.rs
+++ b/tests/src/common.rs
@@ -23,6 +23,10 @@ pub fn init_program(
         &[b"keyring_program".as_ref(), b"global_state".as_ref()],
         &program.id(),
     );
+    let (key_registry, _) = Pubkey::find_program_address(
+        &[b"keyring_program".as_ref(), b"active_keys".as_ref()],
+        &program.id(),
+    );
 
     // Initialization with invalid chain id should not work.
     let invalid_chain_id = vec![1; CHAIN_ID_MAX_SIZE + 1];
@@ -30,6 +34,7 @@ pub fn init_program(
         .request()
         .accounts(keyring_network::accounts::Initialize {
             program_state: program_state.clone(),
+            key_registry: key_registry.clone(),
             signer: payer.pubkey(),
             system_program: System::id(),
         })
@@ -44,6 +49,7 @@ pub fn init_program(
         .request()
         .accounts(keyring_network::accounts::Initialize {
             program_state: program_state.clone(),
+            key_registry: key_registry.clone(),
             signer: payer.pubkey(),
             system_program: System::id(),
         })
@@ -58,6 +64,7 @@ pub fn init_program(
         .request()
         .accounts(keyring_network::accounts::Initialize {
             program_state: program_state.clone(),
+            key_registry: key_registry.clone(),
             signer: payer.pubkey(),
             system_program: System::id(),
         })
@@ -72,6 +79,7 @@ pub fn init_program(
         .request()
         .accounts(keyring_network::accounts::Initialize {
             program_state: program_state.clone(),
+            key_registry: key_registry.clone(),
             signer: payer.pubkey(),
             system_program: System::id(),
         })

--- a/tests/src/test_check_credential.rs
+++ b/tests/src/test_check_credential.rs
@@ -50,12 +50,17 @@ fn test_check_credential() {
         key_hash.as_ref(),
     ];
     let (key_mapping_pubkey, _) = Pubkey::find_program_address(&key_mapping_seeds, &program.id());
+    let (key_registry, _) = Pubkey::find_program_address(
+        &[b"keyring_program".as_ref(), b"active_keys".as_ref()],
+        &program.id(),
+    );
 
     let timestamp = get_timestamp(&rpc);
     program
         .request()
         .accounts(keyring_network::accounts::RegisterKey {
             program_state: program_state_pubkey.clone(),
+            key_registry: key_registry.clone(),
             key_mapping: key_mapping_pubkey.clone(),
             signer: payer.pubkey(),
             system_program: System::id(),

--- a/tests/src/test_collect_fees.rs
+++ b/tests/src/test_collect_fees.rs
@@ -50,12 +50,17 @@ fn collect_fees() {
         key_hash.as_ref(),
     ];
     let (key_mapping_pubkey, _) = Pubkey::find_program_address(&key_mapping_seeds, &program.id());
+    let (key_registry, _) = Pubkey::find_program_address(
+        &[b"keyring_program".as_ref(), b"active_keys".as_ref()],
+        &program.id(),
+    );
 
     let timestamp = get_timestamp(&rpc);
     program
         .request()
         .accounts(keyring_network::accounts::RegisterKey {
             program_state: program_state_pubkey.clone(),
+            key_registry: key_registry.clone(),
             key_mapping: key_mapping_pubkey.clone(),
             signer: payer.pubkey(),
             system_program: System::id(),

--- a/tests/src/test_create_credentials.rs
+++ b/tests/src/test_create_credentials.rs
@@ -50,12 +50,17 @@ fn create_credentials() {
         key_hash.as_ref(),
     ];
     let (key_mapping_pubkey, _) = Pubkey::find_program_address(&key_mapping_seeds, &program.id());
+    let (key_registry, _) = Pubkey::find_program_address(
+        &[b"keyring_program".as_ref(), b"active_keys".as_ref()],
+        &program.id(),
+    );
 
     let timestamp = get_timestamp(&rpc);
     program
         .request()
         .accounts(keyring_network::accounts::RegisterKey {
             program_state: program_state_pubkey.clone(),
+            key_registry: key_registry.clone(),
             key_mapping: key_mapping_pubkey.clone(),
             signer: payer.pubkey(),
             system_program: System::id(),
@@ -497,6 +502,7 @@ fn create_credentials() {
         .request()
         .accounts(keyring_network::accounts::RevokeKey {
             program_state: program_state_pubkey.clone(),
+            key_registry: key_registry.clone(),
             key_mapping: key_mapping_pubkey.clone(),
             signer: payer.pubkey(),
             system_program: System::id(),


### PR DESCRIPTION
1. Created a key registry account that can track up to 10 active keys at any given moment. Adding and removing keys takes O(n) time, but since it's restricted to only 10 items, it's a reasonable approach.
2. Small updates to some tests.